### PR TITLE
fix memory leak

### DIFF
--- a/Source/UIViewController+KNSemiModal.m
+++ b/Source/UIViewController+KNSemiModal.m
@@ -200,7 +200,7 @@ const struct KNSemiModalOption KNSemiModalOptionKeys = {
 	
     if (![target.subviews containsObject:view]) {
         // Set associative object
-        objc_setAssociatedObject(view, kSemiModalPresentingViewController, self, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(self.view, kSemiModalPresentingViewController, self, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 
         // Register for orientation changes, so we can update the presenting controller screenshot
         [[NSNotificationCenter defaultCenter] addObserver:self


### PR DESCRIPTION
in origin code, the retain count will increase once in presentSemiView, but will not decrease in dismissSemiModalViewWithCompletion because you get AssociatedObject from prstingTgt.view
