### PR TITLE
Fix :: when rotation is not allowed, semimodal flickers on rotation

### DIFF
--- a/Source/UIViewController+KNSemiModal.h
+++ b/Source/UIViewController+KNSemiModal.h
@@ -43,6 +43,7 @@ extern const struct KNSemiModalOption {
 	__unsafe_unretained NSString *transitionStyle;	 // boxed NSNumber - one of the KNSemiModalTransitionStyle values.
     __unsafe_unretained NSString *disableCancel;     // boxed BOOL. default is NO.
     __unsafe_unretained NSString *backgroundView;     // UIView, custom background.
+    __unsafe_unretained NSString *disableRotation;   // boxed BOOL. default is NO.
 } KNSemiModalOptionKeys;
 
 typedef NS_ENUM(NSUInteger, KNSemiModalTransitionStyle) {

--- a/Source/UIViewController+KNSemiModal.m
+++ b/Source/UIViewController+KNSemiModal.m
@@ -20,6 +20,7 @@ const struct KNSemiModalOption KNSemiModalOptionKeys = {
 	.transitionStyle         = @"KNSemiModalTransitionStyle",
     .disableCancel           = @"KNSemiModalOptionDisableCancel",
     .backgroundView          = @"KNSemiModelOptionBackgroundView",
+    .disableRotation         = @"KNSemiModalOptionDisableRotation",
 };
 
 #define kSemiModalViewController           @"PaPQC93kjgzUanz"
@@ -75,6 +76,7 @@ const struct KNSemiModalOption KNSemiModalOptionKeys = {
      KNSemiModalOptionKeys.shadowOpacity : @(0.8),
      KNSemiModalOptionKeys.transitionStyle : @(KNSemiModalTransitionStyleSlideUp),
      KNSemiModalOptionKeys.disableCancel : @(NO),
+     KNSemiModalOptionKeys.disableRotation : @(NO),
 	 }];
 }
 
@@ -128,8 +130,10 @@ const struct KNSemiModalOption KNSemiModalOptionKeys = {
 }
 
 -(void)kn_interfaceOrientationDidChange:(NSNotification*)notification {
-	UIView *overlay = [[self parentTarget] viewWithTag:kSemiModalOverlayTag];
-	[self kn_addOrUpdateParentScreenshotInView:overlay];
+    if(![[[self kn_targetToStoreValues] ym_optionOrDefaultForKey:KNSemiModalOptionKeys.disableRotation] boolValue]) {
+        UIView *overlay = [[self parentTarget] viewWithTag:kSemiModalOverlayTag];
+        [self kn_addOrUpdateParentScreenshotInView:overlay];
+    }
 }
 
 -(UIImageView*)kn_addOrUpdateParentScreenshotInView:(UIView*)screenshotContainer {


### PR DESCRIPTION
In order to fix it, a new BOOL property is added: `disableRotation` by default set to `NO`.
Any app not willing to allow rotation can change this value and the flicker will not happen, as the rotation code will not be triggered.

IMPROVEMENT: Manage all the rotation logic (ie observer, notification, etc)
